### PR TITLE
Fixes minor issues

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10073,10 +10073,17 @@
     - NIST-800-171-3.5.4
     - NIST-800-171-3.13.8
     - DISA-STIG-RHEL-07-040310
+-   name: Register ssh key files
+    find:
+      paths: /etc/ssh
+      patterns: ".*_key"
+      use_regex: yes
+    register: ssh_key_files
 -   name: Ensure permission 0640 on /etc/ssh/*_key
     file:
-        path: /etc/ssh/*_key
+        path: "{{ item.path }}"
         mode: 416
+    with_items: "{{ ssh_key_files.files }}"
     tags:
     - file_permissions_sshd_private_key
     - medium_severity
@@ -10088,10 +10095,16 @@
     - NIST-800-171-3.1.13
     - NIST-800-171-3.13.10
     - DISA-STIG-RHEL-07-040420
+-   name: Register ssh public keys
+    find:
+      paths: /etc/ssh
+      patterns: "*.pub"
+    register: ssh_pub_keys
 -   name: Ensure permission 0644 on /etc/ssh/*.pub
     file:
-        path: /etc/ssh/*.pub
+        path: "{{ item.path }}"
         mode: 420
+    with_items: "{{ ssh_pub_keys.files }}"
     tags:
     - file_permissions_sshd_pub_key
     - medium_severity

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2624,7 +2624,7 @@
     package:
         name: dracut-fips
         state: present
-        when: ansible_distribution == 'Red Hat Enterprise Linux'
+    when: ansible_distribution == 'Red Hat Enterprise Linux'
     tags:
     - package_dracut-fips_installed
     - medium_severity


### PR DESCRIPTION
When testing the role, I encountered the following errors, which are addressed by the commits included in this PR:

TASK [rhel7.nist.800.171 : Ensure dracut-fips is installed] ********************
       fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (yum) module: when Supported parameters include: allow_downgrade, autoremove, bugfix, conf_file, disable_excludes, disable_gpg_check, disable_plugin, disablerepo, download_only, enable_plugin, enablerepo, exclude, install_repoquery, installroot, list, name, releasever, security, skip_broken, state, update_cache, update_only, use_backend, validate_certs"}

TASK [rhel7.nist.800.171 : Ensure permission 0640 on /etc/ssh/*_key] ***********
       fatal: [localhost]: FAILED! => {"changed": false, "msg": "file (/etc/ssh/*_key) is absent, cannot continue", "path": "/etc/ssh/*_key", "state": "absent"}

TASK [rhel7.nist.800.171 : Ensure permission 0644 on /etc/ssh/*.pub] ***********
       fatal: [localhost]: FAILED! => {"changed": false, "msg": "file (/etc/ssh/*.pub) is absent, cannot continue", "path": "/etc/ssh/*.pub", "state": "absent"}

After changes, the play completes successfully.  Tested with Ansible 2.7.2.