### PR TITLE
ensure yum repos have valid section header

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7665,6 +7665,7 @@
     find:
         paths: /etc/yum.repos.d/
         patterns: '*.repo'
+        contains: ^\[.+]$
     register: yum_find
 
 -   name: Ensure gpgcheck Enabled For All yum Package Repositories


### PR DESCRIPTION
Files under yum.repos.d may not have any content (e.g., redhat.repo can be empty), so adding an orphaned gpgcheck=1 will break yum and subsequent tasks. 
This adds a rule to check for a [header] in the file before requiring that gpgcheck=1 is in existence. 